### PR TITLE
Added flag for whether or not including the metric libs + Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /x86_64/
 /*.jar
 !kafka-graphite*.jar
+/RPMS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# default build is for CentOS7, change the base image to fit your build.
+FROM centos:centos7
+MAINTAINER Sebastien Le Digabel "sledigabel@gmail.com"
+
+RUN yum install -y wget make rpmdevtools
+
+ADD Makefile kafka.logrotate kafka.service kafka.spec kafka.sysconfig log4j.properties server.properties kafka-graphite-1.0.0.jar /root/
+
+RUN mkdir /root/RPMS
+
+WORKDIR /root
+
+VOLUME ["/root/RPMS"]
+
+CMD make

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ KAFKA_VERSION ?= 0.8.2.1
 SCALA_VERSION ?= 2.10
 VERSION = $(shell echo $(KAFKA_VERSION) | sed "s/-/_/")
 BUILD_NUMBER ?= 1
+BUILD_METRICS ?= 1
 SOURCE_NAME = kafka_$(SCALA_VERSION)-$(KAFKA_VERSION)
 SOURCE = $(SOURCE_NAME).tgz
 TOPDIR = /tmp/kafka-rpm
@@ -19,8 +20,9 @@ rpm: source
 			--define "source $(SOURCE)" \
 			--define "source_name $(SOURCE_NAME)" \
 			--define "_sourcedir $(PWD)" \
-			--define "_rpmdir $(PWD)" \
+			--define "_rpmdir $(PWD)/RPMS" \
 			--define "_topdir $(TOPDIR)" \
+			--define "build_with_metrics $(BUILD_METRICS)" \
 			kafka.spec
 
 clean:
@@ -41,5 +43,4 @@ KEYS:
 	gpg --import KEYS
 
 $(METRICS_GRAPHITE):
-	@wget -q $(METRICS_GRAPHITE_URL) -O $(METRICS_GRAPHITE)
-
+		@wget -q $(METRICS_GRAPHITE_URL) -O $(METRICS_GRAPHITE)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 kafka-redhat7-rpm
 ---------
 A set of scripts to package kafka into an rpm
-Requires CentOS/RedHat 7.
+Requires CentOS/RedHat 7 or Docker.
 
 Setup
 -----
@@ -11,7 +11,12 @@ Building
 --------
     make rpm
 
-Resulting RPM will be avaliable at $(shell pwd)/x86_64
+or use Docker
+
+    docker build -t kafka-build . && docker run -ti -v `pwd`/RPMS:/root/RPMS kafka-build
+    
+
+Resulting RPM will be available at $(shell pwd)/RPMS/x86_64
 
 Installing and operating
 ------------------------

--- a/kafka.spec
+++ b/kafka.spec
@@ -18,8 +18,11 @@ Source2: kafka.logrotate
 Source3: server.properties
 Source4: log4j.properties
 Source5: kafka.sysconfig
+%if %{build_with_metrics}
+# adding metric specific sources.
 Source6: metrics-graphite-2.2.0.jar
 Source7: kafka-graphite-1.0.0.jar
+%endif
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 Prefix: %{_prefix}
 Vendor: Apache Software Foundation
@@ -53,8 +56,11 @@ install -p -D -m 644 %{S:3} $RPM_BUILD_ROOT%{_conf_dir}/
 install -p -D -m 644 %{S:4} $RPM_BUILD_ROOT%{_conf_dir}/
 install -p -D -m 644 %{S:5} $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/kafka
 install -p -D -m 644 libs/* $RPM_BUILD_ROOT%{_prefix}/kafka/libs
+%if %{build_with_metrics}
+# adding metric specific sources.
 install -p -D -m 644 %{S:6} $RPM_BUILD_ROOT%{_prefix}/kafka/libs
 install -p -D -m 644 %{S:7} $RPM_BUILD_ROOT%{_prefix}/kafka/libs
+%endif
 # stupid systemd fails to expand file paths in runtime
 CLASSPATH=
 for f in $RPM_BUILD_ROOT%{_prefix}/kafka/libs/*.jar
@@ -99,4 +105,3 @@ fi
 %attr(0700,kafka,kafka) %dir %{_data_dir}
 %doc NOTICE
 %doc LICENSE
-


### PR DESCRIPTION
Added the ability to create the RPM from docker (useful on mac and windows hosts).

Also added the graphite metrics libs as optional (enabled by default).

Change-Id: Ifbae14f9e258e941369d8afdf58f5fa2b811b77b
