### PR TITLE
Spec fixes

### DIFF
--- a/kafka.spec
+++ b/kafka.spec
@@ -75,7 +75,7 @@ fi
 %systemd_preun kafka.service
 
 %postun
-%systemd_postun
+%systemd_postun kafka.service
 
 %files
 %defattr(-,root,root)

--- a/kafka.spec
+++ b/kafka.spec
@@ -64,9 +64,9 @@ rm -rf $RPM_BUILD_ROOT
 
 %pre
 /usr/bin/getent group kafka >/dev/null || /usr/sbin/groupadd -r kafka
-if ! /usr/bin/getent passwd kafka >/dev/null ; then
-    /usr/sbin/useradd -r -g kafka -m -d %{_prefix}/kafka -s /bin/bash -c "Kafka" kafka
-fi
+/usr/bin/getent passwd kafka >/dev/null || /usr/sbin/useradd -r \
+  -g kafka -d %{_prefix}/kafka -s /bin/bash -c "Kafka" kafka
+exit 0
 
 %post
 %systemd_post kafka.service


### PR DESCRIPTION
Fix (silently) broken postun scriplet.

With SELinux enabled, a local rpm install would have the useradd command fail to create the /opt/kafka directory, and the package install would fail. The exit 0 fixes this and rpm itself is able to create the directory just fine after %pre is run.

Also, since the kafka user is a system user, the -m was removed since it is not useful to have skel files copied to /opt/kafka (dot bash files).