### PR TITLE
Fixes the Docker build image that looks to off broke in the #6160a56 Graphite update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Sebastien Le Digabel "sledigabel@gmail.com"
 
 RUN yum install -y wget make rpmdevtools
 
-ADD Makefile kafka.logrotate kafka.service kafka.spec kafka.sysconfig log4j.properties kafka-graphite-1.0.4.jar /root/
+ADD Makefile kafka.logrotate kafka.service kafka.spec kafka.sysconfig log4j.properties kafka-graphite-*.jar /root/
 
 RUN mkdir /root/RPMS
 


### PR DESCRIPTION
Fixes the Docker build image that looks to off broke in the #6160a56 Graphite update